### PR TITLE
增加直接从cnki复制到剪切板内容转换支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.DS_Store
 # C extensions
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-.DS_Store
-*.bib
-*.net
+
 # C extensions
 *.so
 
@@ -113,3 +111,8 @@ tests/
 
 # distribution
 .pypirc
+
+# custom
+.DS_Store
+*.bib
+*.net

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 .DS_Store
+*.bib
+*.net
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -86,4 +86,7 @@ Use the console to check for Exception if it does not work as expected.
 
 ![FxL8Cq.png](https://s2.ax1x.com/2019/01/14/FxL8Cq.png)
 
+# Or read the NoteExpress Entry content from the clipboard.
+Then just run `cnki2bib` in the terminal. The corresponding BibTeX Entries will be copied to your clipboard, and an 'out.bib' file is created at the current directory. :smile:
 
+![FxL8Cq.png](https://github.com/SNBQT/share-images/blob/master/cnki2bib.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Converting the NoteExpress (.net) file exported by CNKI (中国知网) to BibTeX
   - [Finally...](#finally)
 - [Tricky Usage](#tricky-usage)
 - [Export NoteExpress .net File on CNKI](#export-noteexpress-net-file-on-cnki)
+- [Copy NoteExpress Entry content to the clipboard.](#copy-noteexpress-entry-content-to-the-clipboard)
 
 <!-- /code_chunk_output -->
 
@@ -42,8 +43,13 @@ pip install cnki2bib
 Make sure it's in your `PATH`.
 
 ```
-cnki2bib [OPTIONS] INPUTFILE
+cnki2bib [OPTIONS] [INPUTFILE]
 ```
+
+Arguments:
+
+- INPUTFILE:
+  - The input .net file to be converted. If left blank, the contents in the clipboard will be used.
 
 Options:
 
@@ -52,8 +58,9 @@ Options:
     - Default: `True`
 
 -  `-od, --outputDefault / -nod, --no-outputDefault`
-    - Whether or not to create a .bib file with the same name as the .net file in its directory.
-    - Default: `True`
+    - Whether or not to create a default .bib file.
+    - It has the same name as the source .net file in its directory.
+    - Or if the input source is clipboard, it will be 'out.bib' in current working directory. - Default: True
 
 -  `-o, --outputfile FILENAME`
     - Create a  certain output .bib file.
@@ -86,7 +93,8 @@ Use the console to check for Exception if it does not work as expected.
 
 ![FxL8Cq.png](https://s2.ax1x.com/2019/01/14/FxL8Cq.png)
 
-# Or read the NoteExpress Entry content from the clipboard.
-Then just run `cnki2bib` in the terminal. The corresponding BibTeX Entries will be copied to your clipboard, and an 'out.bib' file is created at the current directory. :smile:
+# Copy NoteExpress Entry content to the clipboard.
 
 ![FxL8Cq.png](https://github.com/SNBQT/share-images/blob/master/cnki2bib.png?raw=true)
+
+Then just run `cnki2bib` in the terminal. The corresponding BibTeX Entries will be copied to your clipboard, and an 'out.bib' file is created at the current directory. :smile:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Use the console to check for Exception if it does not work as expected.
 
 # Copy NoteExpress Entry content to the clipboard.
 
+You have to enable Flash to see the "Copy to clipboard" button.
+
 ![FxL8Cq.png](https://github.com/SNBQT/share-images/blob/master/cnki2bib.png?raw=true)
 
 Then just run `cnki2bib` in the terminal. The corresponding BibTeX Entries will be copied to your clipboard, and an 'out.bib' file is created at the current directory. :smile:

--- a/cnki2bibtex/cnki2bib.py
+++ b/cnki2bibtex/cnki2bib.py
@@ -20,11 +20,17 @@ def copyToClipBoard(content):
 @click.command()
 @click.argument("inputFile", type=click.Path(exists=True, dir_okay=False), required=False)
 @click.option("--copy/--no-copy", "-c/-nc", default=True, help="Whether or not to copy the result to clipboard. Default: True")
-@click.option("--outputDefault/--no-outputDefault", "-od/-nod", default=True, help="Whether or not to create a .bib file with the same name as the .net file in its directory. Default: True")
+@click.option("--outputDefault/--no-outputDefault", "-od/-nod", default=True, help="Whether or not to create a default .bib file. It has the same name as the source .net file in its directory. Or if the input source is clipboard, it will be 'out.bib' in current working directory. Default: True")
 @click.option("--outputfile", "-o", type=click.File('w', encoding="utf-8"), help="Create a certain output .bib file.")
 @click.option("--id-format", "-f", type=click.Choice(['title', 'nameyear']), help="Choose the format of the ID. Pinyin of the first words in the title, or pinyin of the first author plus year")
 def launch(inputfile, copy, outputdefault, outputfile, id_format):
-    '''Converting a NoteExpress Entry .net file exported by CNKI to BibTeX .bib file.'''
+    '''Converting a NoteExpress Entry .net file exported by CNKI to BibTeX .bib file.
+
+\b
+Arguments:
+
+    INPUTFILE: Optional. The input .net file to be converted. If left empty, the contents in the clipboard will be used.'''
+
     if not copy and not outputdefault and not outputfile:
         click.echo("Why are you calling me ???")
         return

--- a/cnki2bibtex/cnki2bib.py
+++ b/cnki2bibtex/cnki2bib.py
@@ -18,7 +18,7 @@ def copyToClipBoard(content):
 
 
 @click.command()
-@click.argument("inputFile", type=click.Path(exists=True, dir_okay=False))
+@click.argument("inputFile", type=click.Path(exists=False, dir_okay=False), required=False)
 @click.option("--copy/--no-copy", "-c/-nc", default=True, help="Whether or not to copy the result to clipboard. Default: True")
 @click.option("--outputDefault/--no-outputDefault", "-od/-nod", default=True, help="Whether or not to create a .bib file with the same name as the .net file in its directory. Default: True")
 @click.option("--outputfile", "-o", type=click.File('w', encoding="utf-8"), help="Create a certain output .bib file.")
@@ -30,18 +30,21 @@ def launch(inputfile, copy, outputdefault, outputfile, id_format):
         click.echo("Why are you calling me ???")
         return
 
-    if os.path.splitext(inputfile)[1] != ".net":
-        logging.warning(
-            "The input file may not be a NoteExpress Entries file.")
+    if inputfile != None:
+        if os.path.splitext(inputfile)[1] != ".net":
+            logging.warning(
+                "The input file may not be a NoteExpress Entries file.")
 
-    if id_format:
-        setIDFormat(id_format)
+        if id_format:
+            setIDFormat(id_format)
 
-    try:
-        with open(inputfile, 'r', encoding="utf-8") as f:
-            cnkiNetFileContent = f.read()
-    except:
-        click.echo("Failed to open the file. Please check input path.")
+        try:
+            with open(inputfile, 'r', encoding="utf-8") as f:
+                cnkiNetFileContent = f.read()
+        except:
+            click.echo("Failed to open the file. Please check input path.")
+    else:
+        cnkiNetFileContent = pyperclip.paste()
 
     try:
         bibFileString = getBibFileContentString(cnkiNetFileContent)
@@ -59,7 +62,8 @@ def launch(inputfile, copy, outputdefault, outputfile, id_format):
 
     if outputdefault:
         try:
-            targetPath = os.path.splitext(inputfile)[0] + ".bib"
+            targetPath = (os.path.splitext(inputfile)[
+                          0] if outputfile else "out") + ".bib"
             with open(targetPath, "w", encoding="utf-8") as f:
                 f.write(bibFileString)
             click.echo(

--- a/cnki2bibtex/cnki2bib.py
+++ b/cnki2bibtex/cnki2bib.py
@@ -18,14 +18,13 @@ def copyToClipBoard(content):
 
 
 @click.command()
-@click.argument("inputFile", type=click.Path(exists=False, dir_okay=False), required=False)
+@click.argument("inputFile", type=click.Path(exists=True, dir_okay=False), required=False)
 @click.option("--copy/--no-copy", "-c/-nc", default=True, help="Whether or not to copy the result to clipboard. Default: True")
 @click.option("--outputDefault/--no-outputDefault", "-od/-nod", default=True, help="Whether or not to create a .bib file with the same name as the .net file in its directory. Default: True")
 @click.option("--outputfile", "-o", type=click.File('w', encoding="utf-8"), help="Create a certain output .bib file.")
 @click.option("--id-format", "-f", type=click.Choice(['title', 'nameyear']), help="Choose the format of the ID. Pinyin of the first words in the title, or pinyin of the first author plus year")
 def launch(inputfile, copy, outputdefault, outputfile, id_format):
     '''Converting a NoteExpress Entry .net file exported by CNKI to BibTeX .bib file.'''
-
     if not copy and not outputdefault and not outputfile:
         click.echo("Why are you calling me ???")
         return
@@ -44,6 +43,7 @@ def launch(inputfile, copy, outputdefault, outputfile, id_format):
         except:
             click.echo("Failed to open the file. Please check input path.")
     else:
+        click.echo("Read the NoteExpress Entry content from the clipboard.")
         cnkiNetFileContent = pyperclip.paste()
 
     try:
@@ -63,7 +63,7 @@ def launch(inputfile, copy, outputdefault, outputfile, id_format):
     if outputdefault:
         try:
             targetPath = (os.path.splitext(inputfile)[
-                          0] if outputfile else "out") + ".bib"
+                          0] if inputfile else "out") + ".bib"
             with open(targetPath, "w", encoding="utf-8") as f:
                 f.write(bibFileString)
             click.echo(

--- a/cnki2bibtex/cnki2bib.py
+++ b/cnki2bibtex/cnki2bib.py
@@ -72,11 +72,15 @@ Arguments:
                           0] if inputfile else "out") + ".bib"
             with open(targetPath, "w", encoding="utf-8") as f:
                 f.write(bibFileString)
-            click.echo(
-                "File '{}' is created at the same directory as the source file.".format(os.path.basename(targetPath)))
+
+            if inputfile:
+                click.echo(
+                    "File '{}' is created at the same directory as the source file.".format(os.path.basename(targetPath)))
+            else:
+                click.echo("File 'out.bib' is created at current directory.")
         except Exception as e:
             click.echo(
-                "Failed to write a .bib file at the same directory as the source file.")
+                "Failed to write the default output .bib file.")
             click.echo("Error message:\n" + str(e))
 
     if outputfile:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open(r'README.md',"r",encoding="utf-8") as f:
 
 setup(
     name='cnki2bib',
-    version='0.2.4',
+    version='0.2.5',
     author='Vopaaz',
     author_email="liyifan945@163.com",
     url="https://github.com/Vopaaz/CNKI_2_BibTeX",


### PR DESCRIPTION
增加直接从cnki复制到剪切板内容转换支持，转换结果输出到剪贴板和默认文件为out.bib,  可避免文件下载和运行指令需指定文件名的繁琐操作，提高工具使用效率